### PR TITLE
rebuild with libxml2 2.10:

### DIFF
--- a/w
+++ b/w
@@ -19,7 +19,8 @@ source:
       - patches/webengine/0003-win.patch             # [win]
       - patches/webengine/0004-win8.patch            # [win]
 
-  - git_url: https://code.qt.io/qt/qtwebengine-chromium.git  # [not win]
+        #- git_url: https://code.qt.io/cgit/qt/qtwebengine-chromium.git  # [not win]
+  - git_url:  https://github.com/qt/qtwebengine-chromium.git # [not win]
     git_rev: 87-based             # [not win]
     folder: qtwebengine-chromium  # [not win]
     patches:                      # [not win]


### PR DESCRIPTION
 - libxml2 pinned to 2.10
 - includes updates to 'about' section
 - build number increased
 - urls updated