### PR TITLE
Remove dependency on OpenSSL (PKG-2412) [skip ci]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,7 @@
 build_parameters:
   - ""
 
+channels:
+  jcmorin-ana-org: qt
+
+upload_without_merge: true

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,6 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
-  - ""
+  - "--skip-existing"
 
 channels:
   jcmorin-ana-org: qt

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -148,6 +148,8 @@ if [[ $(uname) == "Darwin" ]]; then
 
     # sed -i '' -e 's/-Werror//' $PREFIX/mkspecs/features/qt_module_headers.prf
 
+    # TODO: Figure out why this isn't printing a summary on osx...
+    # While being there, we should also figure out why "set -x" doens't seem to be applied...
     qmake QMAKE_LIBDIR=${PREFIX}/lib \
         INCLUDEPATH+="${PREFIX}/include" \
         CONFIG+="warn_off" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,10 @@ pushd qtwebengine-chromium
     awk 'NR==77{$0="    rebase_path(\"'$CONDA_BUILD_SYSROOT'\", root_build_dir),"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
+
+    awk 'NR==79{$0="    \"-isystem='$PREFIX/include'\",\n  ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
+    rm chromium/build/config/mac/BUILD.gn
+    mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
   fi
   # we don't want to play with git ... too slow ...
 popd

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,17 +2,6 @@ set -exou
 
 export NINJAFLAGS=-j3
 
-echo '-asdadsafinhoih124nklhsiohl'
-echo $PREFIX
-set -x
-ls -la $PREFIX/include/c++/v1/
-ls -la $PREFIX/include/c++/v1/__iterator
-ls -la $BUILD_PREFIX/include/c++/v1/
-ls -la $BUILD_PREFIX/include/c++/v1/__iterator
-set +x
-
-echo "Bash: $(which bash)"
-
 pushd qtwebengine-chromium
 
   if [[ $(uname) == "Darwin" ]]; then
@@ -26,10 +15,6 @@ pushd qtwebengine-chromium
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
 
-    echo '++++-----lklkhhasfgs'
-    echo "${PREFIX}/include"
-    echo "NR==79{\$0=\"    \\\"-isystem=${PREFIX}/include\\\",\n  ]\"}1"
-    echo '++++-----lklkhhasfgs'
     awk 'NR==79{$0="    \"-isystem\",\n    \"/Users/builder/jcmorin/miniconda/envs/qt-webengine/include/c++/v1\",\n    \"-nostdinc++\",\n  ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
@@ -75,6 +60,14 @@ if [[ $target_platform == osx-* ]]; then
     fi
     export CONFIG_SHELL="/bin/bash"
     export SHELL="/bin/bash" 
+
+    cat > asdasdasd << EOF
+PREFIX: $PREFIX
+BUILD_PREFIX: $BUILD_PREFIX
+EOF
+    ls -la $BUILD_PREFIX/bin
+
+    cat asdasdasd
 fi
 
 # required to populate include ...

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,8 @@ set -exou
 
 export NINJAFLAGS=-j3
 
+echo '-asdadsafinhoih124nklhsiohl'
+echo $PREFIX
 set -x
 ls -la $PREFIX/include/c++/v1/
 ls -la $PREFIX/include/c++/v1/__iterator
@@ -13,11 +15,15 @@ pushd qtwebengine-chromium
 
   if [[ $(uname) == "Darwin" ]]; then
     # Ensure that Chromium is built using the correct sysroot in Mac
-    awk 'NR==77{$0="    rebase_path(\"'$CONDA_BUILD_SYSROOT'\", root_build_dir),"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
+    awk 'NR==77{$0="    \"'$CONDA_BUILD_SYSROOT'\","}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
 
-    awk 'NR==79{$0="    \"-isystem='$PREFIX/include'\",\n  ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
+    echo '++++-----lklkhhasfgs'
+    echo "${PREFIX}/include"
+    echo "NR==79{\$0=\"    \\\"-isystem=${PREFIX}/include\\\",\n  ]\"}1"
+    echo '++++-----lklkhhasfgs'
+    awk "NR==79{\$0=\"    \\\"-isystem=${PREFIX}/include\\\",\n  ]\"}1" chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
   fi
@@ -29,6 +35,9 @@ pushd src/3rdparty
   # copy the patched 3rdparty stuff ... and make sure we don't play with git
   rm -rf *
   cp -R ../../../qtwebengine-chromium/* .
+
+  echo 'Content of chromium/build/config/mac/BUILD.gn'
+  cat chromium/build/config/mac/BUILD.gn
 popd
 
 if [[ $target_platform == osx-* ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,11 +21,16 @@ pushd qtwebengine-chromium
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
 
+
+    awk 'NR==95{$0="  ldflags += [ \"-L/Users/builder/jcmorin/miniconda/envs/qt-webengine/lib\", \"-nostdlib++\", \"-Wl,-rpath,/Users/builder/jcmorin/miniconda/envs/qt-webengine/lib\", \"-lc++\" ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
+    rm chromium/build/config/mac/BUILD.gn
+    mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
+
     echo '++++-----lklkhhasfgs'
     echo "${PREFIX}/include"
     echo "NR==79{\$0=\"    \\\"-isystem=${PREFIX}/include\\\",\n  ]\"}1"
     echo '++++-----lklkhhasfgs'
-    awk "NR==79{\$0=\"    \\\"-isystem\\\",\n    \\\"/Users/builder/jcmorin/miniconda/envs/qt-webengine/include/c++/v1\\\",\n    \\\"-nostdinc++\\\",\n    \\\"-nostdlib++\\\",\n  ]\"}1" chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
+    awk 'NR==79{$0="    \"-isystem\",\n    \"/Users/builder/jcmorin/miniconda/envs/qt-webengine/include/c++/v1\",\n    \"-nostdinc++\",\n  ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
   fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,8 @@ ls -la $BUILD_PREFIX/include/c++/v1/
 ls -la $BUILD_PREFIX/include/c++/v1/__iterator
 set +x
 
+echo "Bash: $(which bash)"
+
 pushd qtwebengine-chromium
 
   if [[ $(uname) == "Darwin" ]]; then
@@ -23,7 +25,7 @@ pushd qtwebengine-chromium
     echo "${PREFIX}/include"
     echo "NR==79{\$0=\"    \\\"-isystem=${PREFIX}/include\\\",\n  ]\"}1"
     echo '++++-----lklkhhasfgs'
-    awk "NR==79{\$0=\"    \\\"-isystem=${PREFIX}/include\\\",\n  ]\"}1" chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
+    awk "NR==79{\$0=\"    \\\"-isystem\\\",\n    \\\"/Users/builder/jcmorin/miniconda/envs/qt-webengine/include/c++/v1\\\",\n    \\\"-nostdinc++\\\",\n    \\\"-nostdlib++\\\",\n  ]\"}1" chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
   fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,13 @@ set -exou
 
 export NINJAFLAGS=-j3
 
+set -x
+ls -la $PREFIX/include/c++/v1/
+ls -la $PREFIX/include/c++/v1/__iterator
+ls -la $BUILD_PREFIX/include/c++/v1/
+ls -la $BUILD_PREFIX/include/c++/v1/__iterator
+set +x
+
 pushd qtwebengine-chromium
 
   if [[ $(uname) == "Darwin" ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,14 +10,13 @@ pushd qtwebengine-chromium
     rm chromium/build/config/mac/BUILD.gn
     mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
 
+    # awk 'NR==95{$0="  ldflags += [ \"-L/Users/builder/jcmorin/miniconda/envs/qt-webengine/lib\", \"-nostdlib++\", \"-Wl,-rpath,/Users/builder/jcmorin/miniconda/envs/qt-webengine/lib\", \"-lc++\" ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
+    # rm chromium/build/config/mac/BUILD.gn
+    # mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
 
-    awk 'NR==95{$0="  ldflags += [ \"-L/Users/builder/jcmorin/miniconda/envs/qt-webengine/lib\", \"-nostdlib++\", \"-Wl,-rpath,/Users/builder/jcmorin/miniconda/envs/qt-webengine/lib\", \"-lc++\" ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
-    rm chromium/build/config/mac/BUILD.gn
-    mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
-
-    awk 'NR==79{$0="    \"-isystem\",\n    \"/Users/builder/jcmorin/miniconda/envs/qt-webengine/include/c++/v1\",\n    \"-nostdinc++\",\n  ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
-    rm chromium/build/config/mac/BUILD.gn
-    mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
+    # awk 'NR==79{$0="    \"-isystem\",\n    \"/Users/builder/jcmorin/miniconda/envs/qt-webengine/include/c++/v1\",\n    \"-nostdinc++\",\n  ]"}1' chromium/build/config/mac/BUILD.gn > chromium/build/config/mac/BUILD.gn.tmp
+    # rm chromium/build/config/mac/BUILD.gn
+    # mv chromium/build/config/mac/BUILD.gn.tmp chromium/build/config/mac/BUILD.gn
   fi
   # we don't want to play with git ... too slow ...
 popd
@@ -154,8 +153,8 @@ if [[ $(uname) == "Darwin" ]]; then
         CONFIG+="warn_off" \
         QMAKE_CFLAGS_WARN_ON="-w" \
         QMAKE_CXXFLAGS_WARN_ON="-w" \
-        QMAKE_CFLAGS+="-Wno-everything -isystem=${PREFIX}/include" \
-        QMAKE_CXXFLAGS+="-Wno-everything -isystem=${PREFIX}/include" \
+        QMAKE_CFLAGS+="-Wno-everything" \
+        QMAKE_CXXFLAGS+="-Wno-everything" \
         $EXTRA_FLAGS \
         QMAKE_LFLAGS+="-w -Wno-everything -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib" \
         PKG_CONFIG_EXECUTABLE=$(which pkg-config) \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,9 +27,6 @@ pushd src/3rdparty
   # copy the patched 3rdparty stuff ... and make sure we don't play with git
   rm -rf *
   cp -R ../../../qtwebengine-chromium/* .
-
-  echo 'Content of chromium/build/config/mac/BUILD.gn'
-  cat chromium/build/config/mac/BUILD.gn
 popd
 
 if [[ $target_platform == osx-* ]]; then
@@ -60,14 +57,6 @@ if [[ $target_platform == osx-* ]]; then
     fi
     export CONFIG_SHELL="/bin/bash"
     export SHELL="/bin/bash" 
-
-    cat > asdasdasd << EOF
-PREFIX: $PREFIX
-BUILD_PREFIX: $BUILD_PREFIX
-EOF
-    ls -la $BUILD_PREFIX/bin
-
-    cat asdasdasd
 fi
 
 # required to populate include ...

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -152,8 +152,8 @@ if [[ $(uname) == "Darwin" ]]; then
         CONFIG+="warn_off" \
         QMAKE_CFLAGS_WARN_ON="-w" \
         QMAKE_CXXFLAGS_WARN_ON="-w" \
-        QMAKE_CFLAGS+="-Wno-everything" \
-        QMAKE_CXXFLAGS+="-Wno-everything" \
+        QMAKE_CFLAGS+="-Wno-everything -isystem=${PREFIX}/include" \
+        QMAKE_CXXFLAGS+="-Wno-everything -isystem=${PREFIX}/include" \
         $EXTRA_FLAGS \
         QMAKE_LFLAGS+="-w -Wno-everything -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib" \
         PKG_CONFIG_EXECUTABLE=$(which pkg-config) \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -149,7 +149,7 @@ requirements:
     - openssl {{ openssl }}
   run:
     - {{ pin_compatible("qt-main", min_pin="x.x", max_pin="x") }}
-    - openssl
+    - openssl  # exact pin handled through openssl run_exports
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
     - qt >=5.15.2,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,7 @@ source:
     sha256: 4a9dc893cc0a1695a16102a42ef47ef2e228652891f4afea67fadd452b63656b  # [win]
 
 build:
-  #trigger 1
-  number: 6
+  number: 7
   detect_binary_files_with_prefix: true
   skip: true   # [ppc64le or s390x]
   run_exports:
@@ -138,16 +137,17 @@ requirements:
     # - icu
     # - libpng
     # - libiconv
-    # - nspr                               # [unix]
-    # - nss                                # [unix]
+    - nspr                               # [unix]
+    - nss                                # [unix]
     # - sqlite
     # - zlib
     - libxcb                             # [linux]
     - qt-main
     # - libwebp
-    - openssl                            # [win]
+    - openssl {{ openssl }}
   run:
     - {{ pin_compatible("qt-main", min_pin="x.x", max_pin="x") }}
+    - openssl 3.*
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
     - qt >=5.15.2,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -146,10 +146,8 @@ requirements:
     - libxcb                             # [linux]
     - qt-main
     # - libwebp
-    - openssl {{ openssl }}
   run:
     - {{ pin_compatible("qt-main", min_pin="x.x", max_pin="x") }}
-    - openssl  # exact pin handled through openssl run_exports
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
     - qt >=5.15.2,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,8 @@ source:
 build:
   number: 7
   detect_binary_files_with_prefix: true
-  skip: true   # [ppc64le or s390x]
+  # skip: true   # [ppc64le or s390x]
+  skip: true # [not (osx and arm64)]
   run_exports:
     - {{ pin_subpackage('qt-webengine', max_pin='x.x') }}
   missing_dso_whitelist:  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -147,7 +147,7 @@ requirements:
     - openssl {{ openssl }}
   run:
     - {{ pin_compatible("qt-main", min_pin="x.x", max_pin="x") }}
-    - openssl 3.*
+    - openssl
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
     - qt >=5.15.2,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,7 @@ source:
 build:
   number: 7
   detect_binary_files_with_prefix: true
-  # skip: true   # [ppc64le or s390x]
-  skip: true # [not (osx and arm64)]
+  skip: true   # [ppc64le or s390x]
   run_exports:
     - {{ pin_subpackage('qt-webengine', max_pin='x.x') }}
   missing_dso_whitelist:  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
   - url: https://anduin.linuxfromscratch.org/BLFS/qtwebengine/qtwebengine-{{ webengine_version }}.tar.xz
+    sha256: 4b61afcd5b5452d9b3178f28335fb455da543170220f72dba85fe6aa8e76fa39
     folder: qtwebengine
     patches:
       - patches/webengine/qt_webengine-3.15.9.patch  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -137,17 +137,25 @@ requirements:
     - expat                              # [linux]
     - libevent                           # [linux]
     # - icu
-    # - libpng
+    # On linux it seems to be compiling with the system libpng while on mac and Windows
+    # it's compiling its own libpng. This should eventually be sorted out...
+    - libpng {{ libpng }}                # [linux]
     # - libiconv
-    - nspr                               # [unix]
-    - nss                                # [unix]
+    - nspr                               # [linux]
+    - nss                                # [linux]
     # - sqlite
-    # - zlib
+    - zlib {{ zlib }}                    # [linux]
     - libxcb                             # [linux]
     - qt-main
     # - libwebp
   run:
     - {{ pin_compatible("qt-main", min_pin="x.x", max_pin="x") }}
+    # Pinned through libpng run_exports
+    - libpng  # [linux]
+    - nspr  # [linux]
+    - nss  # [linux]
+    # Pinned through zlib run_exports
+    - zlib  # [linux]
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
     - qt >=5.15.2,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,6 +92,7 @@ requirements:
     - {{ cdt('cups-devel') }}            # [linux]
     - {{ cdt('libxcb') }}                # [linux]
     - {{ cdt('expat-devel') }}           # [linux and not aarch64]
+    - {{ cdt('libxkbfile-devel') }}      # [linux]
     - pkg-config                         # [unix]
     - make                               # [unix]
     - cmake
@@ -186,6 +187,7 @@ test:
     - {{ cdt('expat-devel') }}           # [linux and not aarch64]
     - {{ cdt('pcre') }}                  # [linux and not x86_64]
     - {{ cdt('libglvnd-glx') }}          # [linux and not x86_64]
+    - {{ cdt('libxkbfile-devel') }}      # [linux]
     - make                               # [unix]
   files:
     - test/webengine/main-qtwebengine.cpp

--- a/recipe/patches/webengine/0004-win8.patch
+++ b/recipe/patches/webengine/0004-win8.patch
@@ -1119,8 +1119,8 @@ Index: qtwebengine/src/3rdparty/chromium/base/win/windows_version.cc
 +// Platform-specific code for Win32.
 +#undef NTDDI_VERSION
 +#undef _WIN32_WINNT
-+#define NTDDI_VERSION 0xA00
-+#define _WIN32_WINNT 0xA00
++#define NTDDI_VERSION NTDDI_WIN8
++#define _WIN32_WINNT _WIN32_WINNT_WIN8
 +
  #include "base/win/windows_version.h"
  

--- a/recipe/run_webengine_test.bat
+++ b/recipe/run_webengine_test.bat
@@ -1,4 +1,4 @@
-pushd test/webengine
+pushd test\webengine
 if exist .qmake.stash del /a .qmake.stash
 
 :: Only test that this builds


### PR DESCRIPTION
Remove the dependency on OpenSSL.

While doing the work for OpenSSL 3, I noticed that `qt-webengine` doesn't need OpenSSL. `qt-webengine` embbeds and vendors Chromium (the web browser on which Google Chrome is based on), which uses a vendored version of most of its libraries (and we don't want to unvendor them), and one of these is BoringSSL (Google's fork of OpenSSL).

Changes:
* Remove OpenSSL as a host and runtime dependency.
* Add missing dependency on `libxkbfile-devel` that was preventing the linux builds to work.
* Fix the Windows build by modifying one of the patches.
* Fix the Windows tests. A `/` was used in a path instead of `\` and cmd wasn't happy.
* Remove some DSO warnings by adding `libpng`, `nspr`, `nss` and `zlib` as a host and runtime dependency on Linux.

Additional notes:
* The `osx-64` and `osx-arm64` are failing on prefect but are working when run manually on the prefect machines.
* I manually built the `osx-64` and `osx-arm64` variants and published them on https://anaconda.org/jcmorin-ana-org/qt-webengine.
* All variants are now properly built
* I intend to add `[skip-ci]` in the PR title just before merging to avoid having to re-build during the merge. I will manually download the artifacts on zeus and I'll do the release with scotty, as usual.

Depends on:
* https://github.com/AnacondaRecipes/qt-main-feedstock/pull/5