### PR TITLE
rebuild for libxml2 2.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,6 @@ build_parameters:
   - "--skip-existing"
 
 channels:
-  jcmorin-ana-org: qt
+  cbouss: qt
 
 upload_without_merge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     sha256: 4a9dc893cc0a1695a16102a42ef47ef2e228652891f4afea67fadd452b63656b  # [win]
 
 build:
-  number: 7
+  number: 8
   detect_binary_files_with_prefix: true
   skip: true   # [ppc64le or s390x]
   run_exports:
@@ -132,7 +132,7 @@ requirements:
     # - gstreamer
     - libglib                            # [linux and not (aarch64 or x86_64)]
     - glib                               # [linux and (aarch64 or x86_64)]
-    - libxml2  2.10                      # [linux]
+    - libxml2  2.13                      # [linux]
     - libxkbcommon                       # [linux]
     - expat                              # [linux]
     - libevent                           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,9 @@ source:
       - patches/webengine/qt_remove_override.patch
 
   - git_url: https://code.qt.io/qt/qtwebengine-chromium.git # [not win]
-    git_rev: 87-based             # [not win]
+    #git_rev: 87-based             # [not win]
+    # reuse same commit as previous build b7
+    git_rev: 8df91f886e7fffb61408e2426f8a90d763a3b6ea             # [not win]
     folder: qtwebengine-chromium  # [not win]
     patches:                      # [not win]
       - patches/webengine/0001-aarch64-sys-state-structs.patch  # [aarch64]
@@ -36,6 +38,8 @@ build:
   number: 8
   detect_binary_files_with_prefix: true
   skip: true   # [ppc64le or s390x]
+  # skipping win and osx temporarily. The rebuild b8 is for libxml2 which is only used on linux.
+  skip: true   # [win or osx]
   run_exports:
     - {{ pin_subpackage('qt-webengine', max_pin='x.x') }}
   missing_dso_whitelist:  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,7 +99,7 @@ requirements:
     - pkg-config                         # [unix]
     - make                               # [unix]
     - cmake
-    - ninja
+    - ninja 1.10.2
     - ruby >=2.5                         # [linux]
     - bison                              # [linux]
     - flex                               # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -146,7 +146,7 @@ requirements:
     # - sqlite
     - zlib {{ zlib }}                    # [linux]
     - libxcb                             # [linux]
-    - qt-main
+    - qt-main 5.15
     # - libwebp
   run:
     - {{ pin_compatible("qt-main", min_pin="x.x", max_pin="x") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,24 +98,24 @@ requirements:
     - {{ cdt('libxkbfile-devel') }}      # [linux]
     - pkg-config                         # [unix]
     - make                               # [unix]
-    - cmake
+    - cmake 3.26.4
     - ninja 1.10.2
     - ruby >=2.5                         # [linux]
-    - bison                              # [linux]
-    - flex                               # [linux]
-    - gperf                              # [linux]
+    - bison 3.7.5                        # [linux]
+    - flex 2.6.4                         # [linux]
+    - gperf 3.1                          # [linux]
     - perl 5.*
-    - readline                           # [linux]
+    - readline 8.1                       # [linux]
     - jom                                # [win]
-    - nodejs >=16
-    - libtool  # [unix]
+    - nodejs 18.16
+    - libtool 2.4.6 # [unix]
     - sed   # [unix]
     - gawk  # [unix]
     - llvm-tools  # [osx]
-    - binutils    # [linux]
+    - binutils 2.38   # [linux]
     - ldid  # [osx]
   host:
-    - binutils    # [linux]
+    - binutils 2.38   # [linux]
     - llvmdev     # [osx]
     - clangdev    # [osx]
     - llvm-tools  # [osx]
@@ -129,27 +129,27 @@ requirements:
     - pulseaudio                         # [linux and not (aarch64 or x86_64)]
     # - gstreamer
     - pthread-stubs                      # [linux]
-    - dbus                               # [linux]
-    - fontconfig                         # [linux]
-    - freetype                           # [linux]
+    - dbus 1.13.18                       # [linux]
+    - fontconfig 2.14.1                  # [linux]
+    - freetype 2.10.4                    # [linux]
     # - gst-plugins-base
     # - gstreamer
     - libglib                            # [linux and not (aarch64 or x86_64)]
-    - glib                               # [linux and (aarch64 or x86_64)]
+    - glib 2.69.1                        # [linux and (aarch64 or x86_64)]
     - libxml2  2.13                      # [linux]
-    - libxkbcommon                       # [linux]
-    - expat                              # [linux]
-    - libevent                           # [linux]
+    - libxkbcommon 1.0.1                 # [linux]
+    - expat 2.6.4                        # [linux]
+    - libevent 2.1.12                    # [linux]
     # - icu
     # On linux it seems to be compiling with the system libpng while on mac and Windows
     # it's compiling its own libpng. This should eventually be sorted out...
     - libpng {{ libpng }}                # [linux]
     # - libiconv
-    - nspr                               # [linux]
-    - nss                                # [linux]
+    - nspr 4.35                          # [linux]
+    - nss 3.89.1                         # [linux]
     # - sqlite
     - zlib {{ zlib }}                    # [linux]
-    - libxcb                             # [linux]
+    - libxcb 1.15                        # [linux]
     - qt-main 5.15
     # - libwebp
   run:


### PR DESCRIPTION
rebuild for libxml2 2.13 

This is required to ship the most recent libxml2 package in the next installer release.

Only linux variants depend on libxml2. Skipping other platforms as a result.

Rebuilding the same commit of qtwebengine-chromium that was used for b7, and similar pinnings. (This is recorded in the conda package in file `info/git`.)
