### PR TITLE
Replace strip_prefix with prefix in anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -2,4 +2,4 @@ anaconda_config_version: 1
 upstream_sources:
   - git:
       identifier: https://code.qt.io/qt/qtwebengine-chromium.git
-      strip_prefix: v
+      prefix: v


### PR DESCRIPTION
## Summary
- Replace legacy `strip_prefix` with `prefix` in `anaconda.yaml`.

## Verification
- Config-only key rename; no recipe changes.

Made with [Cursor](https://cursor.com)